### PR TITLE
ApiErrors messages aren't readable.

### DIFF
--- a/force/error.go
+++ b/force/error.go
@@ -2,6 +2,7 @@ package force
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Custom Error to handle salesforce api responses.
@@ -16,15 +17,16 @@ type ApiError struct {
 }
 
 func (e ApiErrors) Error() string {
-	return fmt.Sprintf("%#v", e.Errors())
+	return e.String()
 }
 
-func (e ApiErrors) Errors() []string {
-	eArr := make([]string, len(e))
+func (e ApiErrors) String() string {
+	s := make([]string, len(e))
 	for i, err := range e {
-		eArr[i] = err.Error()
+		s[i] = err.String()
 	}
-	return eArr
+
+	return strings.Join(s, "\n")
 }
 
 func (e ApiErrors) Validate() bool {
@@ -36,6 +38,10 @@ func (e ApiErrors) Validate() bool {
 }
 
 func (e ApiError) Error() string {
+	return e.String()
+}
+
+func (e ApiError) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 


### PR DESCRIPTION
Currently the ApiErrors Error message isn't readable. When you get ApiErrors the result looks something like this:
Failed to query: (func() []string)(0x4cf90)
