### PR TITLE
Encapsulate Force Object

### DIFF
--- a/force/limits.go
+++ b/force/limits.go
@@ -7,11 +7,11 @@ type Limit struct {
 	Max       float64
 }
 
-func GetLimits() (limits *Limits, err error) {
-	uri := apiResources[limitsKey]
+func (forceApi *ForceApi) GetLimits() (limits *Limits, err error) {
+	uri := forceApi.apiResources[limitsKey]
 
 	limits = &Limits{}
-	err = get(uri, nil, limits)
+	err = forceApi.get(uri, nil, limits)
 
 	return
 }

--- a/force/limits_test.go
+++ b/force/limits_test.go
@@ -4,12 +4,9 @@ import (
 	"testing"
 )
 
-func init() {
-	initTest()
-}
-
 func TestLimits(t *testing.T) {
-	limits, err := GetLimits()
+	forceApi := createTest()
+	limits, err := forceApi.GetLimits()
 	if err != nil {
 		// Developer Accounts, which the testbed uses, do not have access to the limits API. So this will always fail.
 		// t.Fatalf("Failed to get Limits: %v", err)

--- a/force/oauth_test.go
+++ b/force/oauth_test.go
@@ -4,13 +4,10 @@ import (
 	"testing"
 )
 
-func init() {
-	initTest()
-}
-
 func TestOauth(t *testing.T) {
+	forceApi := createTest()
 	// Verify oauth object is valid
-	if err := oauth.Validate(); err != nil {
+	if err := forceApi.oauth.Validate(); err != nil {
 		t.Fatalf("Oauth object is invlaid: %#v", err)
 	}
 }

--- a/force/query.go
+++ b/force/query.go
@@ -21,14 +21,14 @@ func BuildQuery(fields, table string, constraints []string) string {
 
 // Use the Query resource to execute a SOQL query that returns all the results in a single response,
 // or if needed, returns part of the results and an identifier used to retrieve the remaining results.
-func Query(query string, out interface{}) (err error) {
-	uri := apiResources[queryKey]
+func (forceApi *ForceApi) Query(query string, out interface{}) (err error) {
+	uri := forceApi.apiResources[queryKey]
 
 	params := url.Values{
 		"q": {query},
 	}
 
-	err = get(uri, params, out)
+	err = forceApi.get(uri, params, out)
 
 	return
 }
@@ -36,20 +36,20 @@ func Query(query string, out interface{}) (err error) {
 // Use the QueryAll resource to execute a SOQL query that includes information about records that have
 // been deleted because of a merge or delete. Use QueryAll rather than Query, because the Query resource
 // will automatically filter out items that have been deleted.
-func QueryAll(query string, out interface{}) (err error) {
-	uri := apiResources[queryAllKey]
+func (forceApi *ForceApi) QueryAll(query string, out interface{}) (err error) {
+	uri := forceApi.apiResources[queryAllKey]
 
 	params := url.Values{
 		"q": {query},
 	}
 
-	err = get(uri, params, out)
+	err = forceApi.get(uri, params, out)
 
 	return
 }
 
-func QueryNext(uri string, out interface{}) (err error) {
-	err = get(uri, nil, out)
+func (forceApi *ForceApi) QueryNext(uri string, out interface{}) (err error) {
+	err = forceApi.get(uri, nil, out)
 
 	return
 }

--- a/force/query_test.go
+++ b/force/query_test.go
@@ -11,23 +11,20 @@ const (
 	queryAll = "SELECT %v FROM Account WHERE Id = '%v'"
 )
 
-func init() {
-	initTest()
-}
-
 type AccountQueryResponse struct {
 	sobjects.BaseQuery
 	Records []sobjects.Account `json:"Records" force:"records"`
 }
 
 func TestQuery(t *testing.T) {
-	desc, err := DescribeSObject(&sobjects.Account{})
+	forceApi := createTest()
+	desc, err := forceApi.DescribeSObject(&sobjects.Account{})
 	if err != nil {
 		t.Fatalf("Failed to retrieve description of sobject: %v", err)
 	}
 
 	list := &AccountQueryResponse{}
-	err = Query(BuildQuery(desc.AllFields, desc.Name, nil), list)
+	err = forceApi.Query(BuildQuery(desc.AllFields, desc.Name, nil), list)
 	if err != nil {
 		t.Fatalf("Failed to query: %v", err)
 	}
@@ -36,18 +33,19 @@ func TestQuery(t *testing.T) {
 }
 
 func TestQueryAll(t *testing.T) {
+	forceApi := createTest()
 	// First Insert and Delete an Account
-	newId := insertSObject(t)
-	deleteSObject(t, newId)
+	newId := insertSObject(forceApi, t)
+	deleteSObject(forceApi, t, newId)
 
 	// Then look for it.
-	desc, err := DescribeSObject(&sobjects.Account{})
+	desc, err := forceApi.DescribeSObject(&sobjects.Account{})
 	if err != nil {
 		t.Fatalf("Failed to retrieve description of sobject: %v", err)
 	}
 
 	list := &AccountQueryResponse{}
-	err = QueryAll(fmt.Sprintf(queryAll, desc.AllFields, newId), list)
+	err = forceApi.QueryAll(fmt.Sprintf(queryAll, desc.AllFields, newId), list)
 	if err != nil {
 		t.Fatalf("Failed to queryAll: %v", err)
 	}

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -19,12 +19,12 @@ type SObjectResponse struct {
 	Success bool      `force:"success,omitempty"`
 }
 
-func DescribeSObject(in SObject) (resp *SObjectDescription, err error) {
+func (forceApi *ForceApi) DescribeSObject(in SObject) (resp *SObjectDescription, err error) {
 	// Check cache
-	resp, ok := apiSObjectDescriptions[in.ApiName()]
+	resp, ok := forceApi.apiSObjectDescriptions[in.ApiName()]
 	if !ok {
 		// Attempt retrieval from api
-		sObjectMetaData, ok := apiSObjects[in.ApiName()]
+		sObjectMetaData, ok := forceApi.apiSObjects[in.ApiName()]
 		if !ok {
 			err = fmt.Errorf("Unable to find metadata for object: %v", in.ApiName())
 			return
@@ -33,7 +33,7 @@ func DescribeSObject(in SObject) (resp *SObjectDescription, err error) {
 		uri := sObjectMetaData.URLs[sObjectDescribeKey]
 
 		resp = &SObjectDescription{}
-		err = get(uri, nil, resp)
+		err = forceApi.get(uri, nil, resp)
 		if err != nil {
 			return
 		}
@@ -56,68 +56,71 @@ func DescribeSObject(in SObject) (resp *SObjectDescription, err error) {
 			resp.AllFields = allFields.String()
 		}
 
-		apiSObjectDescriptions[in.ApiName()] = resp
+		forceApi.apiSObjectDescriptions[in.ApiName()] = resp
 	}
 
 	return
 }
 
 // TODO: Add fields parameter to only retireve needed fields.
-func GetSObject(id string, out SObject) (err error) {
-	uri := strings.Replace(apiSObjects[out.ApiName()].URLs[rowTemplateKey], idKey, id, 1)
+func (forceApi *ForceApi) GetSObject(id string, out SObject) (err error) {
+	uri := strings.Replace(forceApi.apiSObjects[out.ApiName()].URLs[rowTemplateKey], idKey, id, 1)
 
-	err = get(uri, nil, out.(interface{}))
+	err = forceApi.get(uri, nil, out.(interface{}))
 
 	return
 }
 
-func InsertSObject(in SObject) (resp *SObjectResponse, err error) {
-	uri := apiSObjects[in.ApiName()].URLs[sObjectKey]
+func (forceApi *ForceApi) InsertSObject(in SObject) (resp *SObjectResponse, err error) {
+	uri := forceApi.apiSObjects[in.ApiName()].URLs[sObjectKey]
 
 	resp = &SObjectResponse{}
-	err = post(uri, nil, in.(interface{}), resp)
+	err = forceApi.post(uri, nil, in.(interface{}), resp)
 
 	return
 }
 
-func UpdateSObject(id string, in SObject) (err error) {
-	uri := strings.Replace(apiSObjects[in.ApiName()].URLs[rowTemplateKey], idKey, id, 1)
+func (forceApi *ForceApi) UpdateSObject(id string, in SObject) (err error) {
+	uri := strings.Replace(forceApi.apiSObjects[in.ApiName()].URLs[rowTemplateKey], idKey, id, 1)
 
-	err = patch(uri, nil, in.(interface{}), nil)
+	err = forceApi.patch(uri, nil, in.(interface{}), nil)
 
 	return
 }
 
-func DeleteSObject(id string, in SObject) (err error) {
-	uri := strings.Replace(apiSObjects[in.ApiName()].URLs[rowTemplateKey], idKey, id, 1)
+func (forceApi *ForceApi) DeleteSObject(id string, in SObject) (err error) {
+	uri := strings.Replace(forceApi.apiSObjects[in.ApiName()].URLs[rowTemplateKey], idKey, id, 1)
 
-	err = delete(uri, nil)
+	err = forceApi.delete(uri, nil)
 
 	return
 }
 
 // TODO: Add fields parameter to only retireve needed fields.
-func GetSObjectByExternalId(id string, out SObject) (err error) {
-	uri := fmt.Sprintf("%v/%v/%v", apiSObjects[out.ApiName()].URLs[sObjectKey], out.ExternalIdApiName(), id)
+func (forceApi *ForceApi) GetSObjectByExternalId(id string, out SObject) (err error) {
+	uri := fmt.Sprintf("%v/%v/%v", forceApi.apiSObjects[out.ApiName()].URLs[sObjectKey],
+		out.ExternalIdApiName(), id)
 
-	err = get(uri, nil, out.(interface{}))
+	err = forceApi.get(uri, nil, out.(interface{}))
 
 	return
 }
 
-func UpsertSObjectByExternalId(id string, in SObject) (resp *SObjectResponse, err error) {
-	uri := fmt.Sprintf("%v/%v/%v", apiSObjects[in.ApiName()].URLs[sObjectKey], in.ExternalIdApiName(), id)
+func (forceApi *ForceApi) UpsertSObjectByExternalId(id string, in SObject) (resp *SObjectResponse, err error) {
+	uri := fmt.Sprintf("%v/%v/%v", forceApi.apiSObjects[in.ApiName()].URLs[sObjectKey],
+		in.ExternalIdApiName(), id)
 
 	resp = &SObjectResponse{}
-	err = patch(uri, nil, in.(interface{}), resp)
+	err = forceApi.patch(uri, nil, in.(interface{}), resp)
 
 	return
 }
 
-func DeleteSObjectByExternalId(id string, in SObject) (err error) {
-	uri := fmt.Sprintf("%v/%v/%v", apiSObjects[in.ApiName()].URLs[sObjectKey], in.ExternalIdApiName(), id)
+func (forceApi *ForceApi) DeleteSObjectByExternalId(id string, in SObject) (err error) {
+	uri := fmt.Sprintf("%v/%v/%v", forceApi.apiSObjects[in.ApiName()].URLs[sObjectKey],
+		in.ExternalIdApiName(), id)
 
-	err = delete(uri, nil)
+	err = forceApi.delete(uri, nil)
 
 	return
 }

--- a/force/sobjects_test.go
+++ b/force/sobjects_test.go
@@ -23,14 +23,11 @@ func (t *CustomSObject) ApiName() string {
 	return "CustomObject__c"
 }
 
-func init() {
-	initTest()
-}
-
 func TestDescribeSObject(t *testing.T) {
+	forceApi := createTest()
 	acc := &sobjects.Account{}
 
-	desc, err := DescribeSObject(acc)
+	desc, err := forceApi.DescribeSObject(acc)
 	if err != nil {
 		t.Fatalf("Cannot retrieve SObject Description for Account SObject: %v", err)
 	}
@@ -39,10 +36,11 @@ func TestDescribeSObject(t *testing.T) {
 }
 
 func TestGetSObject(t *testing.T) {
+	forceApi := createTest()
 	// Test Standard Object
 	acc := &sobjects.Account{}
 
-	err := GetSObject(AccountId, acc)
+	err := forceApi.GetSObject(AccountId, acc)
 	if err != nil {
 		t.Fatalf("Cannot retrieve SObject Account: %v", err)
 	}
@@ -52,7 +50,7 @@ func TestGetSObject(t *testing.T) {
 	// Test Custom Object
 	customObject := &CustomSObject{}
 
-	err = GetSObject(CustomObjectId, customObject)
+	err = forceApi.GetSObject(CustomObjectId, customObject)
 	if err != nil {
 		t.Fatalf("Cannot retrieve SObject CustomObject: %v", err)
 	}
@@ -61,6 +59,7 @@ func TestGetSObject(t *testing.T) {
 }
 
 func TestUpdateSObject(t *testing.T) {
+	forceApi := createTest()
 	// Need some random text for updating a field.
 	rand.Seed(time.Now().UTC().UnixNano())
 	someText := randomString(10)
@@ -69,13 +68,13 @@ func TestUpdateSObject(t *testing.T) {
 	acc := &sobjects.Account{}
 	acc.Name = someText
 
-	err := UpdateSObject(AccountId, acc)
+	err := forceApi.UpdateSObject(AccountId, acc)
 	if err != nil {
 		t.Fatalf("Cannot update SObject Account: %v", err)
 	}
 
 	// Read back and verify
-	err = GetSObject(AccountId, acc)
+	err = forceApi.GetSObject(AccountId, acc)
 	if err != nil {
 		t.Fatalf("Cannot retrieve SObject Account: %v", err)
 	}
@@ -88,11 +87,12 @@ func TestUpdateSObject(t *testing.T) {
 }
 
 func TestInsertDeleteSObject(t *testing.T) {
-	objectId := insertSObject(t)
-	deleteSObject(t, objectId)
+	forceApi := createTest()
+	objectId := insertSObject(forceApi, t)
+	deleteSObject(forceApi, t, objectId)
 }
 
-func insertSObject(t *testing.T) string {
+func insertSObject(forceApi *ForceApi, t *testing.T) string {
 	// Need some random text for name field.
 	rand.Seed(time.Now().UTC().UnixNano())
 	someText := randomString(10)
@@ -101,7 +101,7 @@ func insertSObject(t *testing.T) string {
 	acc := &sobjects.Account{}
 	acc.Name = someText
 
-	resp, err := InsertSObject(acc)
+	resp, err := forceApi.InsertSObject(acc)
 	if err != nil {
 		t.Fatalf("Insert SObject Account failed: %v", err)
 	}
@@ -113,17 +113,17 @@ func insertSObject(t *testing.T) string {
 	return resp.Id
 }
 
-func deleteSObject(t *testing.T, id string) {
+func deleteSObject(forceApi *ForceApi, t *testing.T, id string) {
 	// Test Standard Object
 	acc := &sobjects.Account{}
 
-	err := DeleteSObject(id, acc)
+	err := forceApi.DeleteSObject(id, acc)
 	if err != nil {
 		t.Fatalf("Delete SObject Account failed: %v", err)
 	}
 
 	// Read back and verify
-	err = GetSObject(id, acc)
+	err = forceApi.GetSObject(id, acc)
 	if err == nil {
 		t.Fatalf("Delete SObject Account failed, was able to retrieve deleted object: %+v", acc)
 	}


### PR DESCRIPTION
Encapsulate the force object so multiple force.com API sessions can be used at runtime.
