### PR TITLE
Added fields parameter to GetSObject and GetSObjectByExternalId

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ func main() {
 
 	// Get somCustomSObject by ID
 	someCustomSObject := &SomeCustomSObject{}
-	err = forceApi.GetSObject("Your-Object-ID", someCustomSObject)
+	err = forceApi.GetSObject("Your-Object-ID", nil, someCustomSObject)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"net/url"
 )
 
 // Interface all standard and custom objects must implement. Needed for uri generation.
@@ -62,11 +63,15 @@ func (forceApi *ForceApi) DescribeSObject(in SObject) (resp *SObjectDescription,
 	return
 }
 
-// TODO: Add fields parameter to only retireve needed fields.
-func (forceApi *ForceApi) GetSObject(id string, out SObject) (err error) {
+func (forceApi *ForceApi) GetSObject(id string, fields []string, out SObject) (err error) {
 	uri := strings.Replace(forceApi.apiSObjects[out.ApiName()].URLs[rowTemplateKey], idKey, id, 1)
 
-	err = forceApi.Get(uri, nil, out.(interface{}))
+	params := url.Values{}
+	if len(fields) > 0 {
+		params.Add("fields", strings.Join(fields, ","))
+	}
+
+	err = forceApi.Get(uri, params, out.(interface{}))
 
 	return
 }
@@ -96,12 +101,16 @@ func (forceApi *ForceApi) DeleteSObject(id string, in SObject) (err error) {
 	return
 }
 
-// TODO: Add fields parameter to only retireve needed fields.
-func (forceApi *ForceApi) GetSObjectByExternalId(id string, out SObject) (err error) {
+func (forceApi *ForceApi) GetSObjectByExternalId(id string, fields []string, out SObject) (err error) {
 	uri := fmt.Sprintf("%v/%v/%v", forceApi.apiSObjects[out.ApiName()].URLs[sObjectKey],
 		out.ExternalIdApiName(), id)
 
-	err = forceApi.Get(uri, nil, out.(interface{}))
+	params := url.Values{}
+	if len(fields) > 0 {
+		params.Add("fields", strings.Join(fields, ","))
+	}
+
+	err = forceApi.Get(uri, params, out.(interface{}))
 
 	return
 }

--- a/force/sobjects_test.go
+++ b/force/sobjects_test.go
@@ -19,6 +19,7 @@ type CustomSObject struct {
 	AccountId string `force:"Account__c"`
 }
 
+
 func (t *CustomSObject) ApiName() string {
 	return "CustomObject__c"
 }
@@ -40,7 +41,7 @@ func TestGetSObject(t *testing.T) {
 	// Test Standard Object
 	acc := &sobjects.Account{}
 
-	err := forceApi.GetSObject(AccountId, acc)
+	err := forceApi.GetSObject(AccountId, nil, acc)
 	if err != nil {
 		t.Fatalf("Cannot retrieve SObject Account: %v", err)
 	}
@@ -50,12 +51,24 @@ func TestGetSObject(t *testing.T) {
 	// Test Custom Object
 	customObject := &CustomSObject{}
 
-	err = forceApi.GetSObject(CustomObjectId, customObject)
+	err = forceApi.GetSObject(CustomObjectId, nil, customObject)
 	if err != nil {
 		t.Fatalf("Cannot retrieve SObject CustomObject: %v", err)
 	}
 
 	t.Logf("SObject CustomObject Retrieved: %+v", customObject)
+
+	// Test Custom Object Field Retrieval
+	fields := []string{"Name", "Id"}
+
+	accFields := &sobjects.Account{}
+
+	err = forceApi.GetSObject(AccountId, fields, accFields)
+	if err != nil {
+		t.Fatalf("Cannot retrieve SObject Account fields: %v", err)
+	}
+
+	t.Logf("SObject Account Name and Id Retrieved: %+v", accFields)
 }
 
 func TestUpdateSObject(t *testing.T) {
@@ -74,7 +87,7 @@ func TestUpdateSObject(t *testing.T) {
 	}
 
 	// Read back and verify
-	err = forceApi.GetSObject(AccountId, acc)
+	err = forceApi.GetSObject(AccountId, nil, acc)
 	if err != nil {
 		t.Fatalf("Cannot retrieve SObject Account: %v", err)
 	}
@@ -123,7 +136,7 @@ func deleteSObject(forceApi *ForceApi, t *testing.T, id string) {
 	}
 
 	// Read back and verify
-	err = forceApi.GetSObject(id, acc)
+	err = forceApi.GetSObject(id, nil, acc)
 	if err == nil {
 		t.Fatalf("Delete SObject Account failed, was able to retrieve deleted object: %+v", acc)
 	}


### PR DESCRIPTION
Added the fields parameter to the GetSObject and GetSObjectByExternalId functions as a slice of strings. They are joined by commas, and then passed to the request function as a url.Values argument.