### PR TITLE
Add usage of omitempty tag to Struct for related external reference ids

### DIFF
--- a/forcejson/encode.go
+++ b/forcejson/encode.go
@@ -285,6 +285,13 @@ var byteSliceType = reflect.TypeOf([]byte(nil))
 
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !isEmptyValue(v.Field(i)) {
+				return false
+			}
+		}
+		return true
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
 	case reflect.Bool:

--- a/forcejson/encode_test.go
+++ b/forcejson/encode_test.go
@@ -25,13 +25,17 @@ type Optionals struct {
 
 	Mr map[string]interface{} `force:"mr"`
 	Mo map[string]interface{} `force:",omitempty"`
+
+	Str struct{} `force:"str"`
+	Sto struct{} `force:",omitempty"`
 }
 
 var optionalsExpected = `{
  "sr": "",
  "omitempty": 0,
  "slr": null,
- "mr": {}
+ "mr": {},
+ "str": {}
 }`
 
 func TestOmitEmpty(t *testing.T) {


### PR DESCRIPTION
Found myself wanting to add the following to account sobject struct:

Parent     struct {
	External_Id__c float64 `force:",omitempty"`
} `force:",omitempty"`

Wasn't playing nice until I adjusted encode.go to allow omitting empty Structs.

Kevin McClellan