### PR TITLE
If A Field Is A String And A Value Is A Bool, Set The String Value Of The Bool

### DIFF
--- a/forcejson/decode.go
+++ b/forcejson/decode.go
@@ -676,7 +676,15 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 				d.saveError(&UnmarshalTypeError{"bool", v.Type()})
 			}
 		case reflect.String:
-			v.SetString(fmt.Sprintf("%t", value))
+			if string(item[:]) == "true" || string(item[:]) == "false" {
+				v.SetString(fmt.Sprintf("%t", value))
+			} else {
+				if fromQuoted {
+					d.saveError(fmt.Errorf("force: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+				} else {
+					d.saveError(&UnmarshalTypeError{"bool", v.Type()})
+				}
+			}
 		case reflect.Bool:
 			v.SetBool(value)
 		case reflect.Interface:

--- a/forcejson/decode.go
+++ b/forcejson/decode.go
@@ -675,6 +675,8 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			} else {
 				d.saveError(&UnmarshalTypeError{"bool", v.Type()})
 			}
+		case reflect.String:
+			v.SetString(fmt.Sprintf("%t", value))
 		case reflect.Bool:
 			v.SetBool(value)
 		case reflect.Interface:


### PR DESCRIPTION
This PR is more tolerant of "bare" (unquoted) default values which represent boolean values. If the value is `true` or `false`, defaultValue will be set to `"true"` or `"false"`.