### PR TITLE
Create methods to get InstanceURL and AccessToken

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -203,3 +203,11 @@ func (forceApi *ForceApi) getApiSObjectDescriptions() error {
 
 	return nil
 }
+
+func (forceApi *ForceApi) GetInstanceURL() string {
+	return forceApi.oauth.InstanceUrl
+}
+
+func (forceApi *ForceApi) GetAccessToken() string {
+	return forceApi.oauth.AccessToken
+}


### PR DESCRIPTION
ForceApi.oauth is private, so I can't get this values outside the package.
Both InstanceURL and AccessToken are need to use CreateWithAccessToken method.