### PR TITLE
Add CalculatedFormula field to SObjectField type

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -113,6 +113,7 @@ type SObjectField struct {
 	Unique                   bool             `json:"unique"`
 	CaseSensitive            bool             `json:"caseSensitive"`
 	Calculated               bool             `json:"calculated"`
+	CalculatedFormula        string           `json:"calculatedFormula"`
 	Scale                    float64          `json:"scale"`
 	Label                    string           `json:"label"`
 	NamePointing             bool             `json:"namePointing"`


### PR DESCRIPTION
This patch adds CalculatedFormula to SObjectField. I've tested it on my project, the new field fills correctly.