### PR TITLE
Move the documentation for SFBool to the right place

### DIFF
--- a/sobjects/bool.go
+++ b/sobjects/bool.go
@@ -1,3 +1,7 @@
+package sobjects
+
+import "encoding/json"
+
 // Don't use this! It was an interesting effort but in reality all you need is a ptr to a bool. *bool will solve all your problems. :)
 // Used to represent empty bools. Go types are always instantiated with a default value, for bool the default value is false.
 // This makes it difficult to update an SObject without overwriting any boolean field to false.
@@ -10,10 +14,6 @@
 // If no value is set the unmarshaller will skip the field and the int will default to 0.
 // Marshalling: -1 will be marshaled to false, 1 will be marshaled to true, and
 // 0 will be marshaled to nothing (assuming the field has the omitempty json tag `json:",omitempty"`)
-package sobjects
-
-import "encoding/json"
-
 type SFBool int
 
 func (t *SFBool) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Fixes an issue where the SFBool documentation is presented as package level documentation by godoc.org which may lead people to believe that the `sobjects` package should not be used at all.

This can be seen in the screenshot below.

<img width="710" alt="screen shot 2017-06-02 at 11 56 55" src="https://cloud.githubusercontent.com/assets/2704/26723067/9f5d0304-478a-11e7-9cf2-60de654dd0b8.png">
