### PR TITLE
Child relationships lost

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -94,7 +94,7 @@ type SObjectDescription struct {
 	Listviewable        bool                 `json:"listviewable"`
 	DeprecatedAndHidden bool                 `json:"deprecatedAndHidden"`
 	RecordTypeInfos     []*RecordTypeInfo    `json:"recordTypeInfos"`
-	ChildRelationsips   []*ChildRelationship `json:"childRelationships"`
+	ChildRelationships  []*ChildRelationship `json:"childRelationships"`
 
 	AllFields string `json:"-"` // Not from force.com API. Used to generate SELECT * queries.
 }


### PR DESCRIPTION
Fixed a typo in the member structure (ChildRelationsips instead of ChildRelationships)
This prevents to discover those parent / child relationships between Force.com objects