### PR TITLE
Refresh token oauth fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "go.inferGopath": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.inferGopath": false
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-go-force
-======
+# go-force
+
 <p align="center">
   <a href="https://goreportcard.com/report/github.com/nimajalali/go-force"><img src="https://goreportcard.com/badge/github.com/nimajalali/go-force" alt="Go Report Card"></a>
   <a href="https://github.com/nimajalali/go-force/actions?query=workflow%3Abuild"><img src="https://github.com/nimajalali/go-force/workflows/build/badge.svg" alt="build status"></a>
@@ -12,12 +12,12 @@ go-force
 
 [Golang](http://golang.org/) API wrapper for [Force.com](http://www.force.com/), [Salesforce.com](http://www.salesforce.com/)
 
-Installation
-============
-	go get github.com/nimajalali/go-force/force
+# Installation
 
-Example
-============
+    go get github.com/nimajalali/go-force/force
+
+# Example
+
 ```go
 package main
 
@@ -31,7 +31,7 @@ import (
 
 type SomeCustomSObject struct {
 	sobjects.BaseSObject
-	
+
 	Active    bool   `force:"Active__c"`
 	AccountId string `force:"Account__c"`
 }
@@ -80,8 +80,8 @@ func main() {
 	fmt.Printf("%#v", someCustomSObjects)
 }
 ```
-Documentation 
-=======
 
-* [Package Reference](http://godoc.org/github.com/nimajalali/go-force/force)
-* [Force.com API Reference](http://www.salesforce.com/us/developer/docs/api_rest/)
+# Documentation
+
+- [Package Reference](http://godoc.org/github.com/nimajalali/go-force/force)
+- [Force.com API Reference](http://www.salesforce.com/us/developer/docs/api_rest/)

--- a/force/force.go
+++ b/force/force.go
@@ -89,11 +89,11 @@ func CreateWithAccessToken(version, clientId, accessToken, instanceUrl string) (
 	return forceApi, nil
 }
 
-func CreateWithRefreshToken(version, clientId, accessToken, instanceUrl string) (*ForceApi, error) {
+func CreateWithRefreshToken(version, clientId, refreshToken, instanceUrl string) (*ForceApi, error) {
 	oauth := &forceOauth{
-		clientId:    clientId,
-		AccessToken: accessToken,
-		InstanceUrl: instanceUrl,
+		clientId:     clientId,
+		refreshToken: refreshToken,
+		InstanceUrl:  instanceUrl,
 	}
 
 	forceApi := &ForceApi{

--- a/force/force_test.go
+++ b/force/force_test.go
@@ -1,8 +1,9 @@
 package force
 
 import (
-	"github.com/nimajalali/go-force/sobjects"
 	"testing"
+
+	"github.com/christopheralme/go-force/sobjects"
 )
 
 func TestCreateWithAccessToken(t *testing.T) {

--- a/force/sobjects_test.go
+++ b/force/sobjects_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nimajalali/go-force/sobjects"
+	"github.com/christopheralme/go-force/sobjects"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/nimajalali/go-force
+module github.com/christopheralme/go-force
 
 go 1.13

--- a/sobjects/date_test.go
+++ b/sobjects/date_test.go
@@ -1,10 +1,11 @@
 package sobjects
 
 import (
-	"github.com/nimajalali/go-force/forcejson"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/christopheralme/go-force/forcejson"
 )
 
 type Thing struct {


### PR DESCRIPTION
Currently the refresh token flow doesn't populate the refresh token and is blank during the CreateWithRefreshToken flow. Update CreateWithRefreshToken to take in the refresh token and use it to get access token